### PR TITLE
Fix subprocess `python` command in Linux

### DIFF
--- a/pyppbox/gui/guitools.py
+++ b/pyppbox/gui/guitools.py
@@ -20,6 +20,7 @@
 
 
 import os
+import sys
 import subprocess as sp
 
 from pyppbox.utils.logtools import add_warning_log, add_error_log
@@ -93,7 +94,7 @@ def launchGUI():
     """Launch GUI configuration tool of pyppbox.
     """
     writeUITMP(__cfgdir__)
-    p = sp.Popen(['python', os.path.join(current_dir, 'ui_launcher.py')])
+    p = sp.Popen([sys.executable, os.path.join(current_dir, 'ui_launcher.py')])
     stdout, stderr = p.communicate()
 
 def generateConfig(cfg_dir, auto_launch_gui=True):

--- a/pyppbox/gui/ui_launcher.py
+++ b/pyppbox/gui/ui_launcher.py
@@ -358,7 +358,7 @@ class Ui_PYPPBOXLauncher(object):
                         self.input_video_file_lineEdit.text(), 
                         self.input_force_hd_comboBox.currentText())
         launcher.hide()
-        p = sp.Popen(['python', os.path.join(current_dir, 'guidemo.py')])
+        p = sp.Popen([sys.executable, os.path.join(current_dir, 'guidemo.py')])
         stdout, stderr = p.communicate()
         self.mycfg.setMCFG()
         launcher.show()


### PR DESCRIPTION
Use `sys.executable` instead of `python` command